### PR TITLE
remove no spatialCoverage message

### DIFF
--- a/earthcube_utilities/src/ec/graph/sparql_files/all_summary_query.sparql
+++ b/earthcube_utilities/src/ec/graph/sparql_files/all_summary_query.sparql
@@ -38,7 +38,6 @@ SELECT distinct ?subj ?g ?resourceType ?name ?description  ?pubname
            # BIND ( IF ( BOUND(?date_p), ?date_p, "No datePublished") as ?datep ) .
             # BIND ( IF ( BOUND(?date_p), ?date_p, "1900-01-01") as ?datep ) .
             BIND ( IF ( BOUND(?pub_name), ?pub_name, "No Publisher") as ?pubname ) .
-            BIND ( IF ( BOUND(?place_name), ?place_name, "No spatialCoverage") as ?placename ) .
              }
         }
         #GROUP BY ?subj ?pubname ?placenames ?kw ?datep   ?name ?description  ?resourceType ?sosType ?maxDepth ?minDepth ?g

--- a/earthcube_utilities/src/ec/graph/sparql_files/repo_summary_query.sparql
+++ b/earthcube_utilities/src/ec/graph/sparql_files/repo_summary_query.sparql
@@ -39,7 +39,6 @@ SELECT distinct ?subj ?g ?resourceType ?name ?description  ?pubname
            # BIND ( IF ( BOUND(?date_p), ?date_p, "No datePublished") as ?datep ) .
            #  BIND ( IF ( BOUND(?date_p), ?date_p, "1900-01-01") as ?datep ) .
             BIND ( IF ( BOUND(?pub_name), ?pub_name, "No Publisher") as ?pubname ) .
-            BIND ( IF ( BOUND(?place_name), ?place_name, "No spatialCoverage") as ?placename ) .
              }
         FILTER( CONTAINS(str(?g), "${repo}") )
         }

--- a/earthcube_utilities/src/ec/graph/sparql_files/tests/all_summary_depth.sparql
+++ b/earthcube_utilities/src/ec/graph/sparql_files/tests/all_summary_depth.sparql
@@ -33,9 +33,8 @@ SELECT distinct ?subj ?g ?resourceType ?name ?description  ?pubname
            # Query should not return "No datePublished" is not a valid Date "YYYY-MM-DD" so
             # UI Date Select failed, because it expects an actual date
            # BIND ( IF ( BOUND(?date_p), ?date_p, "No datePublished") as ?datep ) .
-             BIND ( IF ( BOUND(?date_p), ?date_p, "1900-01-01") as ?datep ) .
+           # BIND ( IF ( BOUND(?date_p), ?date_p, "1900-01-01") as ?datep ) .
             BIND ( IF ( BOUND(?pub_name), ?pub_name, "No Publisher") as ?pubname ) .
-            BIND ( IF ( BOUND(?place_name), ?place_name, "No spatialCoverage") as ?placename ) .
              }
         }
         GROUP BY ?subj ?pubname ?placenames ?kw ?datep   ?name ?description  ?resourceType ?sosType  ?maxdepth ?minDepth ?g


### PR DESCRIPTION
This PR
- removed `no spatialCoverage` message from 3 sparql queries
- commented date in the depth sparql query because other two's were commented